### PR TITLE
 customize open/close tags via 'string-template/custom'

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -73,14 +73,14 @@ function compile(string, inline) {
             var token = replace[k]
 
             if (String(token) === token) {
-                replace[k] = template.process(literalTemplate, escape(token))
+                replace[k] = template(literalTemplate, escape(token))
             } else {
-                replace[k] = template.process(argTemplate, escape(token.name))
+                replace[k] = template(argTemplate, escape(token.name))
             }
         }
 
         var replaceCode = replace.join(" +\n    ")
-        var compiledSource = template.process(replaceTemplate, replaceCode);
+        var compiledSource = template(replaceTemplate, replaceCode);
         return new Function(compiledSource);
     }
 

--- a/custom.js
+++ b/custom.js
@@ -1,0 +1,47 @@
+
+
+var opTag = "{";
+var clTag = "}";
+var nargs = /\{([0-9a-zA-Z]+)\}/g
+
+
+
+function isSpecialRegExpChar( c ) {
+  return "\^$.|?*+()[]{}".indexOf( c ) != -1;
+}
+
+
+function escapeForRegExp( str ) {
+  var l = str.length;
+  var result = "";
+  for( var i=0; i<l; i++ ) {
+    result += ( isSpecialRegExpChar( str[i] ) ? "\\" : "" ) + str[i];
+  }
+  return result;
+}
+
+
+function setOpenCloseTags( op, cl ) {
+  if( op == cl ) {
+    console.log( "ERROR: In setOpenCloseTags, open and close tags must be different to each other." );
+    return;
+  }
+  opTag = op;
+  clTag = cl;
+
+  var op_RegExp, cl_RegExp;
+  op_RegExp = escapeForRegExp( op );
+  cl_RegExp = escapeForRegExp( cl );
+
+  nargs = new RegExp( op_RegExp+"([0-9a-zA-Z]+)"+cl_RegExp, "g" );
+}
+
+
+module.exports.config = function() {
+  return {
+    opTag: opTag,
+    clTag: clTag,
+    nargs: nargs
+  }
+}
+module.exports.setOpenCloseTags = setOpenCloseTags;

--- a/index.js
+++ b/index.js
@@ -1,44 +1,11 @@
 var slice = Array.prototype.slice
 
-var TEMPL_OPEN  = "{";
-var TEMPL_CLOSE = "}";
-var nargs = /\{([0-9a-zA-Z]+)\}/g
+var custom = require('./custom');
 
+module.exports = template
 
-
-function isSpecialRegExpChar( c ) {
-  return "\^$.|?*+()[]{}".indexOf( c ) != -1;
-}
-
-
-function escapeForRegExp( str ) {
-  var l = str.length;
-  var result = "";
-  for( var i=0; i<l; i++ ) {
-    result += ( isSpecialRegExpChar( str[i] ) ? "\\" : "" ) + str[i];
-  }
-  return result;
-}
-
-
-function setOpenCloseTags( op, cl ) {
-  if( op == cl ) {
-    console.log( "ERROR: In setOpenCloseTags, open and close tags must be different to each other." );
-    return;
-  }
-  TEMPL_OPEN  = op;
-  TEMPL_CLOSE = cl;
-
-  var op_RegExp, cl_RegExp;
-  op_RegExp = escapeForRegExp( op );
-  cl_RegExp = escapeForRegExp( cl );
-
-  nargs = new RegExp( op_RegExp+"([0-9a-zA-Z]+)"+cl_RegExp, "g" );
-}
-
-
-function process(string) {
-    var args;
+function template(string) {
+    var args
 
     if (arguments.length === 2 && typeof arguments[1] === "object") {
         args = arguments[1]
@@ -50,11 +17,13 @@ function process(string) {
         args = {}
     }
 
-    return string.replace(nargs, function replaceArg(match, i, index) {
+    var config = custom.config();
+
+    return string.replace(config.nargs, function replaceArg(match, i, index) {
         var result
 
-        if (string[index - 1] === TEMPL_OPEN &&
-            string[index + match.length] === TEMPL_CLOSE) {
+        if (string[index - 1] === config.opTag &&
+            string[index + match.length] === config.clTag) {
             return i
         } else {
             result = args.hasOwnProperty(i) ? args[i] : null
@@ -66,9 +35,3 @@ function process(string) {
         }
     })
 }
-
-
-//---
-
-module.exports.setOpenCloseTags = setOpenCloseTags;
-module.exports.process = process;

--- a/test/custom.js
+++ b/test/custom.js
@@ -1,0 +1,43 @@
+var test = require("tape");
+
+var format = require('../index');
+var custom = require('../custom');
+
+
+
+test("Setting identical open/close tags leads to no action", function (assert) {
+  var config = custom.config();
+  custom.setOpenCloseTags( "<==", "<==" );
+  var newConfig = custom.config();
+  assert.equal( config.nargs, newConfig.nargs );
+  assert.equal( config.opTag, newConfig.opTag );
+  assert.equal( config.clTag, newConfig.clTag );
+
+  assert.end();
+});
+
+
+test("Changing open/close tags works", function (assert) {
+   var objs = {
+       name: "Nicolas",
+       age: "31",
+       city: "Paris" };
+
+   custom.setOpenCloseTags( "{", "}" );
+   var result = format( "Hello {name}, I hear you come from {{city}}?", objs );
+   assert.equal(result, "Hello Nicolas, I hear you come from {city}?");
+
+   custom.setOpenCloseTags( "{{", "}}" );
+   result = format( "Hello {name}, I hear you come from {{city}}?", objs );
+   assert.equal(result, "Hello {name}, I hear you come from Paris?");
+
+   custom.setOpenCloseTags( "<%=", "%>" );
+   result = format( "Hello {name}, I hear you come from {{city}}?", objs );
+   assert.equal(result, "Hello {name}, I hear you come from {{city}}?");
+
+   // restoring standard open/close tags for following tests
+   custom.setOpenCloseTags( "{", "}" );
+
+   assert.end();
+});
+

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
 require("./string-template")
 require("./compile-weak")
 require("./compile-strong")
+require("./custom")

--- a/test/string-template.js
+++ b/test/string-template.js
@@ -1,16 +1,16 @@
 var test = require("tape")
 
-var template = require("../index.js")
+var format = require("../index.js")
 
 test("Named arguments are replaced", function (assert) {
-    var result = template.process("Hello {name}, how are you?", { name: "Mark" })
+    var result = format("Hello {name}, how are you?", { name: "Mark" })
     assert.equal(result, "Hello Mark, how are you?")
     assert.end()
 })
 
 test("Named arguments at the start of strings are replaced",
     function (assert) {
-        var result = template.process("{likes} people have liked this", {
+        var result = format("{likes} people have liked this", {
             likes: 123
         })
 
@@ -20,7 +20,7 @@ test("Named arguments at the start of strings are replaced",
 
 test("Named arguments at the end of string are replaced",
     function (assert) {
-        var result = template.process("Please respond by {date}", {
+        var result = format("Please respond by {date}", {
             date: "01/01/2015"
         })
 
@@ -29,7 +29,7 @@ test("Named arguments at the end of string are replaced",
     })
 
 test("Multiple named arguments are replaced", function (assert) {
-    var result = template.process("Hello {name}, you have {emails} new messages", {
+    var result = format("Hello {name}, you have {emails} new messages", {
         name: "Anna",
         emails: 5
     })
@@ -39,26 +39,26 @@ test("Multiple named arguments are replaced", function (assert) {
 })
 
 test("Missing named arguments become 0 characters", function (assert) {
-    var result = template.process("Hello{name}, how are you?", {})
+    var result = format("Hello{name}, how are you?", {})
     assert.equal(result, "Hello, how are you?")
     assert.end()
 })
 
 test("Named arguments can be escaped", function (assert) {
-    var result = template.process("Hello {{name}}, how are you?", { name: "Mark" })
+    var result = format("Hello {{name}}, how are you?", { name: "Mark" })
     assert.equal(result, "Hello {name}, how are you?")
     assert.end()
 })
 
 test("Array arguments are replaced", function (assert) {
-    var result = template.process("Hello {0}, how are you?", ["Mark"])
+    var result = format("Hello {0}, how are you?", ["Mark"])
     assert.equal(result, "Hello Mark, how are you?")
     assert.end()
 })
 
 test("Array arguments at the start of strings are replaced",
     function (assert) {
-        var result = template.process("{0} people have liked this", [123])
+        var result = format("{0} people have liked this", [123])
 
         assert.equal(result, "123 people have liked this")
         assert.end()
@@ -66,14 +66,14 @@ test("Array arguments at the start of strings are replaced",
 
 test("Array arguments at the end of string are replaced",
     function (assert) {
-        var result = template.process("Please respond by {0}", ["01/01/2015"])
+        var result = format("Please respond by {0}", ["01/01/2015"])
 
         assert.equal(result, "Please respond by 01/01/2015")
         assert.end()
     })
 
 test("Multiple array arguments are replaced", function (assert) {
-    var result = template.process("Hello {0}, you have {1} new messages", [
+    var result = format("Hello {0}, you have {1} new messages", [
         "Anna",
         5
     ])
@@ -83,32 +83,32 @@ test("Multiple array arguments are replaced", function (assert) {
 })
 
 test("Missing array arguments become 0 characters", function (assert) {
-    var result = template.process("Hello{0}, how are you?", [])
+    var result = format("Hello{0}, how are you?", [])
     assert.equal(result, "Hello, how are you?")
     assert.end()
 })
 
 test("Array arguments can be escaped", function (assert) {
-    var result = template.process("Hello {{0}}, how are you?", ["Mark"])
+    var result = format("Hello {{0}}, how are you?", ["Mark"])
     assert.equal(result, "Hello {0}, how are you?")
     assert.end()
 })
 
 test("Array keys are not accessible", function (assert) {
-    var result = template.process("Function{splice}", [])
+    var result = format("Function{splice}", [])
     assert.equal(result, "Function")
     assert.end()
 })
 
 test("Listed arguments are replaced", function (assert) {
-    var result = template.process("Hello {0}, how are you?", "Mark")
+    var result = format("Hello {0}, how are you?", "Mark")
     assert.equal(result, "Hello Mark, how are you?")
     assert.end()
 })
 
 test("Listed arguments at the start of strings are replaced",
     function (assert) {
-        var result = template.process("{0} people have liked this", 123)
+        var result = format("{0} people have liked this", 123)
 
         assert.equal(result, "123 people have liked this")
         assert.end()
@@ -116,14 +116,14 @@ test("Listed arguments at the start of strings are replaced",
 
 test("Listed arguments at the end of string are replaced",
     function (assert) {
-        var result = template.process("Please respond by {0}", "01/01/2015")
+        var result = format("Please respond by {0}", "01/01/2015")
 
         assert.equal(result, "Please respond by 01/01/2015")
         assert.end()
     })
 
 test("Multiple listed arguments are replaced", function (assert) {
-    var result = template.process("Hello {0}, you have {1} new messages",
+    var result = format("Hello {0}, you have {1} new messages",
         "Anna",
         5)
 
@@ -132,35 +132,35 @@ test("Multiple listed arguments are replaced", function (assert) {
 })
 
 test("Missing listed arguments become 0 characters", function (assert) {
-    var result = template.process("Hello{1}, how are you?", "no")
+    var result = format("Hello{1}, how are you?", "no")
     assert.equal(result, "Hello, how are you?")
     assert.end()
 })
 
 test("Listed arguments can be escaped", function (assert) {
-    var result = template.process("Hello {{0}}, how are you?", "Mark")
+    var result = format("Hello {{0}}, how are you?", "Mark")
     assert.equal(result, "Hello {0}, how are you?")
     assert.end()
 })
 
 test("Allow null data", function (assert) {
-    var result = template.process("Hello{0}", null)
+    var result = format("Hello{0}", null)
     assert.equal(result, "Hello")
     assert.end()
 })
 
 test("Allow undefined data", function (assert) {
-    var result1 = template.process("Hello{0}")
-    var result2 = template.process("Hello{0}", undefined)
+    var result1 = format("Hello{0}")
+    var result2 = format("Hello{0}", undefined)
     assert.equal(result1, "Hello")
     assert.equal(result2, "Hello")
     assert.end()
 })
 
 test("Null keys become 0 characters", function (assert) {
-    var result1 = template.process("Hello{name}", { name: null })
-    var result2 = template.process("Hello{0}", [null])
-    var result3 = template.process("Hello{0}{1}{2}", null, null, null)
+    var result1 = format("Hello{name}", { name: null })
+    var result2 = format("Hello{0}", [null])
+    var result3 = format("Hello{0}{1}{2}", null, null, null)
     assert.equal(result1, "Hello")
     assert.equal(result2, "Hello")
     assert.equal(result3, "Hello")
@@ -168,9 +168,9 @@ test("Null keys become 0 characters", function (assert) {
 })
 
 test("Undefined keys become 0 characters", function (assert) {
-    var result1 = template.process("Hello{firstName}{lastName}", { name: undefined })
-    var result2 = template.process("Hello{0}{1}", [undefined])
-    var result3 = template.process("Hello{0}{1}{2}", undefined, undefined)
+    var result1 = format("Hello{firstName}{lastName}", { name: undefined })
+    var result2 = format("Hello{0}{1}", [undefined])
+    var result3 = format("Hello{0}{1}{2}", undefined, undefined)
     assert.equal(result1, "Hello")
     assert.equal(result2, "Hello")
     assert.equal(result3, "Hello")
@@ -178,13 +178,13 @@ test("Undefined keys become 0 characters", function (assert) {
 })
 
 test("Works across multline strings", function (assert) {
-    var result1 = template.process("{zero}\n{one}\n{two}", {
+    var result1 = format("{zero}\n{one}\n{two}", {
         zero: "A",
         one: "B",
         two: "C"
     })
-    var result2 = template.process("{0}\n{1}\n{2}", ["A", "B", "C"])
-    var result3 = template.process("{0}\n{1}\n{2}", "A", "B", "C")
+    var result2 = format("{0}\n{1}\n{2}", ["A", "B", "C"])
+    var result3 = format("{0}\n{1}\n{2}", "A", "B", "C")
     assert.equal(result1, "A\nB\nC")
     assert.equal(result2, "A\nB\nC")
     assert.equal(result3, "A\nB\nC")
@@ -192,17 +192,17 @@ test("Works across multline strings", function (assert) {
 })
 
 test("Allow multiple references", function (assert) {
-    var result1 = template.process("{a}{b}{c}\n{a}{b}{c}\n{a}{b}{c}", {
+    var result1 = format("{a}{b}{c}\n{a}{b}{c}\n{a}{b}{c}", {
         a: "one",
         b: "two",
         c: "three"
     })
-    var result2 = template.process("{0}{1}{2}\n{0}{1}{2}\n{0}{1}{2}", [
+    var result2 = format("{0}{1}{2}\n{0}{1}{2}\n{0}{1}{2}", [
         "one",
         "two",
         "three"
     ])
-    var result3 = template.process("{0}{1}{2}\n{0}{1}{2}\n{0}{1}{2}",
+    var result3 = format("{0}{1}{2}\n{0}{1}{2}\n{0}{1}{2}",
         "one",
         "two",
         "three")
@@ -211,32 +211,3 @@ test("Allow multiple references", function (assert) {
     assert.equal(result3, "onetwothree\nonetwothree\nonetwothree")
     assert.end()
 })
-
-
-
-
-test("Changing open/close tags works", function (assert) {
-   var objs = {
-       name: "Nicolas",
-       age: "31",
-       city: "Paris" };
-
-   template.setOpenCloseTags( "{", "}" );
-   var result = template.process( "Hello {name}, I hear you come from {{city}}?", objs );
-   assert.equal(result, "Hello Nicolas, I hear you come from {city}?");
-
-   template.setOpenCloseTags( "{{", "}}" );
-   result = template.process( "Hello {name}, I hear you come from {{city}}?", objs );
-   assert.equal(result, "Hello {name}, I hear you come from Paris?");
-
-   template.setOpenCloseTags( "<%=", "%>" );
-   result = template.process( "Hello {name}, I hear you come from {{city}}?", objs );
-   assert.equal(result, "Hello {name}, I hear you come from {{city}}?");
-
-   // restorin standard open/close tags for following tests
-   template.setOpenCloseTags( "{", "}" );
-
-   assert.end();
-});
-
-


### PR DESCRIPTION
The main module is now exposing two methods, 'process' (formerly 'template') and 'setOpenCloseTags'
The one-function structure of module.exports is thus changed, maybe requiring a version increment...
As you consider best, Matt.
