### PR TITLE
Update "license" to be SPDX compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,7 @@
   "devDependencies": {
     "tape": "~1.1.1"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/Matt-Esch/string-template/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "test": "node ./test/index.js",
     "travis-test": "istanbul cover ./test/index.js && ((cat coverage/lcov.info | coveralls) || exit 0)",


### PR DESCRIPTION
This fixes package.json to take on the new `license` spec from [npm 2.10.0](https://github.com/npm/npm/releases/tag/v2.10.0).