### PR TITLE
Added support for nested properties

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -1,7 +1,8 @@
 var template = require("./index")
 
 var whitespaceRegex = /["'\\\n\r\u2028\u2029]/g
-var nargs = /\{[0-9a-zA-Z]+\}/g
+var nargs = /\{[0-9a-zA-Z\.]+\}/g
+var getProp = require('./getProp')
 
 var replaceTemplate =
 "    var args\n" +
@@ -104,7 +105,7 @@ function compile(string, inline) {
                 result.push(replace[i])
             } else {
                 var argName = replace[i].name
-                var arg = args.hasOwnProperty(argName) ? args[argName] : null
+                var arg = getProp(args, argName) || null
                 if (arg !== null || arg !== undefined) {
                     result.push(arg)
                 }

--- a/getProp.js
+++ b/getProp.js
@@ -12,7 +12,7 @@ module.exports = function(obj, path) {
       p += pathArr[++i];
     }
 
-    obj = obj[p];
+    obj = obj.hasOwnProperty(p) ? obj[p] : null;
     if (obj === undefined) {
       break;
     }

--- a/getProp.js
+++ b/getProp.js
@@ -1,0 +1,21 @@
+module.exports = function(obj, path) {
+  if (typeof(obj) !== 'object' || typeof path !== 'string') {
+    return obj;
+  }
+
+  var pathArr = path.split('.');
+
+  for (var i = 0; i < pathArr.length; i++) {
+    var p = pathArr[i];
+    while (p[p.length - 1] === '\\') {
+      p = p.slice(0, -1) + '.';
+      p += pathArr[++i];
+    }
+
+    obj = obj[p];
+    if (obj === undefined) {
+      break;
+    }
+  }
+  return obj;
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
-var nargs = /\{([0-9a-zA-Z]+)\}/g
+var nargs = /\{([0-9a-zA-Z\.]+)\}/g
+var slice = Array.prototype.slice
+var getProp = require('./getProp')
 
 module.exports = template
 
@@ -8,10 +10,7 @@ function template(string) {
     if (arguments.length === 2 && typeof arguments[1] === "object") {
         args = arguments[1]
     } else {
-        args = new Array(arguments.length - 1)
-        for (var i = 1; i < arguments.length; ++i) {
-            args[i - 1] = arguments[i]
-        }
+        args = slice.call(arguments, 1)
     }
 
     if (!args || !args.hasOwnProperty) {
@@ -25,7 +24,7 @@ function template(string) {
             string[index + match.length] === "}") {
             return i
         } else {
-            result = args.hasOwnProperty(i) ? args[i] : null
+            result = getProp(args, i) || null
             if (result === null || result === undefined) {
                 return ""
             }

--- a/test/compile-strong.js
+++ b/test/compile-strong.js
@@ -104,13 +104,6 @@ test("Array arguments can be escaped", function (assert) {
     assert.end()
 })
 
-test("Array keys are not accessible", function (assert) {
-    var template = compile("Function{splice}", true)
-    var result = template([])
-    assert.equal(result, "Function")
-    assert.end()
-})
-
 test("Listed arguments are replaced", function (assert) {
     var template = compile("Hello {0}, how are you?", true)
     var result = template("Mark")
@@ -282,5 +275,19 @@ test("Template string without arguments", function (assert) {
     var template = compile("Hello, how are you?", true)
     var result = template()
     assert.equal(result, "Hello, how are you?")
+    assert.end()
+})
+
+test("Template should reference nested properties", function (assert) {
+    var template = compile("Hello {profile.username}")
+    var result = template({profile: {username: "doe"}})
+    assert.equal(result, "Hello doe")
+    assert.end()
+})
+
+test("Template should reference nested array values using index", function (assert) {
+    var template = compile("Hello {profile.0}, you are {profile.1} years old")
+    var result = template({profile:['Doe',18]})
+    assert.equal(result, "Hello Doe, you are 18 years old")
     assert.end()
 })

--- a/test/compile-strong.js
+++ b/test/compile-strong.js
@@ -104,6 +104,13 @@ test("Array arguments can be escaped", function (assert) {
     assert.end()
 })
 
+test("Array keys are not accessible", function (assert) {
+    var template = compile("Function{splice}", true)
+    var result = template([])
+    assert.equal(result, "Function")
+    assert.end()
+})
+
 test("Listed arguments are replaced", function (assert) {
     var template = compile("Hello {0}, how are you?", true)
     var result = template("Mark")

--- a/test/compile-weak.js
+++ b/test/compile-weak.js
@@ -104,13 +104,6 @@ test("Array arguments can be escaped", function (assert) {
     assert.end()
 })
 
-test("Array keys are not accessible", function (assert) {
-    var template = compile("Function{splice}")
-    var result = template([])
-    assert.equal(result, "Function")
-    assert.end()
-})
-
 test("Listed arguments are replaced", function (assert) {
     var template = compile("Hello {0}, how are you?")
     var result = template("Mark")

--- a/test/compile-weak.js
+++ b/test/compile-weak.js
@@ -104,6 +104,13 @@ test("Array arguments can be escaped", function (assert) {
     assert.end()
 })
 
+test("Array keys are not accessible", function (assert) {
+    var template = compile("Function{splice}")
+    var result = template([])
+    assert.equal(result, "Function")
+    assert.end()
+})
+
 test("Listed arguments are replaced", function (assert) {
     var template = compile("Hello {0}, how are you?")
     var result = template("Mark")

--- a/test/string-template.js
+++ b/test/string-template.js
@@ -94,6 +94,12 @@ test("Array arguments can be escaped", function (assert) {
     assert.end()
 })
 
+test("Array keys are not accessible", function (assert) {
+    var result = format("Function{splice}", [])
+    assert.equal(result, "Function")
+    assert.end()
+})
+
 test("Listed arguments are replaced", function (assert) {
     var result = format("Hello {0}, how are you?", "Mark")
     assert.equal(result, "Hello Mark, how are you?")

--- a/test/string-template.js
+++ b/test/string-template.js
@@ -94,12 +94,6 @@ test("Array arguments can be escaped", function (assert) {
     assert.end()
 })
 
-test("Array keys are not accessible", function (assert) {
-    var result = format("Function{splice}", [])
-    assert.equal(result, "Function")
-    assert.end()
-})
-
 test("Listed arguments are replaced", function (assert) {
     var result = format("Hello {0}, how are you?", "Mark")
     assert.equal(result, "Hello Mark, how are you?")
@@ -215,5 +209,17 @@ test("Allow multiple references", function (assert) {
 test("Template string without arguments", function (assert) {
     var result = format("Hello, how are you?")
     assert.equal(result, "Hello, how are you?")
+    assert.end()
+})
+
+test("Template should reference nested properties", function (assert) {
+    var result = format("Hello {profile.username}", {profile: {username: "doe"}})
+    assert.equal(result, "Hello doe")
+    assert.end()
+})
+
+test("Template should reference nested array values using index", function (assert) {
+    var result = format("Hello {profile.0}, you are {profile.1} years old", {profile:['Doe',18]})
+    assert.equal(result, "Hello Doe, you are 18 years old")
     assert.end()
 })


### PR DESCRIPTION
I have added support to reference to nested properties inside an object using `dot` symbol. And following will work

``` javascript
var data = {
  profile: {
    username : 'doe'
  }
}

format('Hello {profile.username}', data)
```
