### PR TITLE
Adding underscore while parsing string templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var nargs = /\{([0-9a-zA-Z]+)\}/g
+var nargs = /\{([0-9a-zA-Z_]+)\}/g
 
 module.exports = template
 

--- a/test/string-template.js
+++ b/test/string-template.js
@@ -217,3 +217,11 @@ test("Template string without arguments", function (assert) {
     assert.equal(result, "Hello, how are you?")
     assert.end()
 })
+
+test("Template string with underscores", function (assert) {
+    var result = format("Hello {FULL_NAME}, how are you?", {
+        FULL_NAME: "James Bond"
+    })
+    assert.equal(result, "Hello James Bond, how are you?")
+    assert.end()
+})


### PR DESCRIPTION
I feel it's common to use `_` in environment variables and I could directly call format('....', process.env) to manipulate the values at runtime.
We use this convention while building configurations from CI servers.