### PR TITLE
adding dot when parsing string templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var nargs = /\{([0-9a-zA-Z_]+)\}/g
+var nargs = /\{([0-9a-zA-Z_.]+)\}/g
 
 module.exports = template
 

--- a/test/string-template.js
+++ b/test/string-template.js
@@ -8,6 +8,12 @@ test("Named arguments are replaced", function (assert) {
     assert.end()
 })
 
+test("Named arguments from flattened objects are replaced", function (assert) {
+    var result = format("Hello {user.name}, how are you?", { "user.name": "Mark" })
+    assert.equal(result, "Hello Mark, how are you?")
+    assert.end()
+})
+
 test("Named arguments at the start of strings are replaced",
     function (assert) {
         var result = format("{likes} people have liked this", {


### PR DESCRIPTION
This is useful to be able to pass flattened objects to the template.

So you can do:

```javascript
var user = { user: { name: 'Mark' }};
var flatUser = flatten(user); // => { "user.name": "Mark" }
var string = format('Hello {user.name}', flatUser);
```

